### PR TITLE
fix: log4shell-goof/log4shell-server/pom.xml to reduce vulnerabilities

### DIFF
--- a/log4shell-goof/log4shell-server/pom.xml
+++ b/log4shell-goof/log4shell-server/pom.xml
@@ -20,22 +20,22 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.15.0</version>
+      <version>2.17.1</version>
     </dependency>
     <dependency>
       <groupId>com.unboundid</groupId>
       <artifactId>unboundid-ldapsdk</artifactId>
-      <version>3.1.1</version>
+      <version>4.0.5</version>
     </dependency>
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>
-      <version>2.2.13.Final</version>
+      <version>2.3.6.Final</version>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078
- https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-472711
- https://snyk.io/vuln/SNYK-JAVA-COMUNBOUNDID-32143
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-2391283
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-2871356
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-3012383
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-3339519
- https://snyk.io/vuln/SNYK-JAVA-IOUNDERTOW-3358786
- https://snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2320014
- https://snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2321524
- https://snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2327339
- https://snyk.io/vuln/SNYK-JAVA-ORGJBOSSXNIO-2994360